### PR TITLE
Add a dot grid background

### DIFF
--- a/dotcom/src/app.css
+++ b/dotcom/src/app.css
@@ -26,8 +26,11 @@ html,
 }
 
 body {
+	--grid: 1.125rem;
+	--grid-double: calc( 2 * var(--grid));
+
 	margin: 0;
-	padding: 1rem;
+	padding: calc(0.5 * var(--grid));
 	font-family: "IBM Plex Sans Variable", sans-serif;
 
 	font-weight: 400;
@@ -40,9 +43,14 @@ body {
 	/* font-variation-settings: "wght" var(--weight), "wdth" var(--weight); */
 
 	font-size: 16px;
-	line-height: 1.5rem;
+	line-height: 18px;
 	background-color: var(--cloud);
 	color: var(--earth);
+
+	background-image: url("/grid.svg");
+
+	background-position: top left;
+	background-size: var(--grid-double) var(--grid-double);
 }
 
 body.themed {
@@ -61,8 +69,8 @@ h3,
 h4,
 h5,
 h6 {
-	margin: 0 0 0.5em 0;
-	line-height: 2rem;
+	margin: 0 0 var(--grid) 0;
+	line-height: calc(2 * var(--grid));
 }
 
 h1 {
@@ -83,4 +91,10 @@ a:hover {
 	color: var(--border);
 	/* text-shadow: 0px 0px 0.0625rem var(--border); */
 	/* background-color: var(--border); */
+}
+
+
+p {
+	margin: 0;
+	padding: var(--grid) 0;
 }

--- a/dotcom/src/app.css
+++ b/dotcom/src/app.css
@@ -3,26 +3,26 @@ html,
 	--earth: hsl(190, 89%, 6%);
 	--ocean: hsl(192, 84%, 30%);
 	--glint: hsl(18, 96%, 60%);
-	--cloud: hsl(192, 18%, 72%);
-	--skies: white;
+	--cloud: hsl(192, 18%, 84%);
+	--skies: hsl(200, 48%, 92%);
 }
 
 @media (prefers-color-scheme: dark) {
 	html {
-		--earth: white;
+		--earth: hsl(200, 48%, 92%);
 		--ocean: hsl(200, 36%, 60%);
 		--glint: hsl(18, 96%, 60%);
 		--cloud: hsl(190, 89%, 12%);
-		--skies: hsl(200, 96%, 3%);
+		--skies: hsl(200, 96%, 6%);
 	}
 }
 
 .dark {
-	--earth: white;
+	--earth: hsl(200, 48%, 92%);
 	--ocean: hsl(200, 36%, 60%);
 	--glint: hsl(18, 96%, 60%);
 	--cloud: hsl(190, 89%, 12%);
-	--skies: hsl(200, 96%, 3%);
+	--skies: hsl(200, 96%, 6%);
 }
 
 body {
@@ -47,10 +47,11 @@ body {
 	background-color: var(--cloud);
 	color: var(--earth);
 
-	background-image: url("/grid.svg");
+	background-image: radial-gradient(circle at center, var(--skies) 1px, transparent 1px);
+	;
 
 	background-position: top left;
-	background-size: var(--grid-double) var(--grid-double);
+	background-size: var(--grid) var(--grid);
 }
 
 body.themed {

--- a/dotcom/src/lib/CMPS.svelte
+++ b/dotcom/src/lib/CMPS.svelte
@@ -8,7 +8,8 @@
 
 <style>
 	svg {
+		display: block;
 		stroke: currentColor;
-		height: 2.25rem;
+		height: calc(2 * var(--grid));
 	}
 </style>

--- a/dotcom/src/lib/Footer.svelte
+++ b/dotcom/src/lib/Footer.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import type { Lang } from "./lang";
+	import Theme from "./Theme.svelte";
 
 	export let lang: Lang;
 </script>
 
 <footer class="footer cf" role="contentinfo">
+	<Theme />
+
 	{#if lang == "en"}
 		<p class="footer-copyright">
 			Hello, it’s Max.<br />
@@ -41,3 +44,11 @@
 	{/if}
 	<div class="wrap wide" />
 </footer>
+
+<style>
+	footer {
+		border-top: 2px solid var(--skies);
+		margin-top: -2px;
+		padding-top: var(--grid);
+	}
+</style>

--- a/dotcom/src/lib/Header.svelte
+++ b/dotcom/src/lib/Header.svelte
@@ -38,7 +38,7 @@
 				{/if}
 			</li>
 
-			<li class="menu-item" lang="fr">
+			<li class="menu-item desktop" lang="fr">
 				<a href="/allo">allô</a>
 				<span class="padded">–</span>
 				<a href="/hi">hi</a>
@@ -84,5 +84,20 @@
 
 	a {
 		background: none;
+	}
+
+	.menu-item a {
+		position: relative;
+		top: 0.125rem;
+	}
+
+	.desktop {
+		display: none;
+	}
+
+	@media screen and (min-width: 740px) {
+		.desktop {
+			display: flex;
+		}
 	}
 </style>

--- a/dotcom/src/lib/Header.svelte
+++ b/dotcom/src/lib/Header.svelte
@@ -48,22 +48,34 @@
 </header>
 
 <style>
+	header {
+		height: calc(var(--grid) * 2);
+		padding-bottom: calc(var(--grid) - 1px);
+		border-bottom: 2px solid var(--skies);
+	}
 
 	ul {
 		display: flex;
 		justify-content: space-between;
-
-		list-style-type: none;
+		align-items: stretch;
+		height: 100%;
 		margin: 0;
 		padding: 0;
+
 		font-weight: 480;
 	}
 
 	li {
-		height: 2.25rem;
 		display: flex;
 		text-transform: uppercase;
 		align-items: center;
+		font-weight: 320;
+		font-size: 1.75rem;
+		line-height: calc(2 * var(--grid));
+	}
+
+	li * {
+		display: block;
 	}
 
 	.padded {
@@ -71,8 +83,6 @@
 	}
 
 	a {
-		display: block;
-		margin: auto;
 		background: none;
 	}
 </style>

--- a/dotcom/src/lib/Header.svelte
+++ b/dotcom/src/lib/Header.svelte
@@ -50,7 +50,7 @@
 <style>
 	header {
 		height: calc(var(--grid) * 2);
-		padding-bottom: calc(var(--grid) - 1px);
+		padding-bottom: var(--grid);
 		border-bottom: 2px solid var(--skies);
 	}
 
@@ -59,7 +59,7 @@
 		justify-content: space-between;
 		align-items: stretch;
 		height: 100%;
-		margin: 0;
+		margin: -1px 0;
 		padding: 0;
 
 		font-weight: 480;

--- a/dotcom/src/lib/Header.svelte
+++ b/dotcom/src/lib/Header.svelte
@@ -52,6 +52,7 @@
 		height: calc(var(--grid) * 2);
 		padding-bottom: var(--grid);
 		border-bottom: 2px solid var(--skies);
+		margin-bottom: -1px;
 	}
 
 	ul {

--- a/dotcom/src/lib/Theme.svelte
+++ b/dotcom/src/lib/Theme.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	const setTheme = (theme: "light" | "dark" | "default") => {
+		document.body.classList.add("themed");
+		const { classList } = document.querySelector("html");
+		classList.remove("light", "dark", "default");
+		switch (theme) {
+			case "light":
+				classList.add("light");
+				localStorage.setItem("theme", "light");
+				break;
+			case "dark":
+				classList.add("dark");
+				localStorage.setItem("theme", "dark");
+				break;
+			case "default":
+				classList.add("default");
+				localStorage.removeItem("theme");
+				break;
+		}
+		return theme;
+	};
+</script>
+
+<button on:click={() => setTheme("light")}>light</button>
+<button on:click={() => setTheme("dark")}>dark</button>
+<button on:click={() => setTheme("default")}>reset</button>
+
+<style>
+	button {
+		height: var(--grid);
+	}
+</style>

--- a/dotcom/src/lib/Works.svelte
+++ b/dotcom/src/lib/Works.svelte
@@ -26,15 +26,15 @@
 <style>
 	ul {
 		display: grid;
-		padding: 1rem;
+		padding: 0;
 		margin: 0;
-		grid-template-columns: repeat(3, 24rem);
-		gap: 1rem;
+		grid-template-columns: repeat(3, calc(12 * var(--grid-double)));
+		gap: var(--grid);
 	}
 
 	li {
 		display: block;
-		height: 6rem;
+		height: calc(3 * var(--grid-double));
 		padding: 0.5rem;
 		border: 0.125rem solid var(--ocean);
 		box-sizing: border-box;

--- a/dotcom/src/lib/Works.svelte
+++ b/dotcom/src/lib/Works.svelte
@@ -34,7 +34,7 @@
 
 	li {
 		display: block;
-		height: calc(3 * var(--grid-double));
+		height: calc(3 * var(--grid-double) + 2px);
 		padding: 0.5rem;
 		border: 0.125rem solid var(--ocean);
 		box-sizing: border-box;

--- a/dotcom/src/lib/Works.svelte
+++ b/dotcom/src/lib/Works.svelte
@@ -38,6 +38,8 @@
 		padding: 0.5rem;
 		border: 0.125rem solid var(--ocean);
 		box-sizing: border-box;
+		margin: -1px;
+		border-radius: 1px;
 	}
 
 	li a {

--- a/dotcom/src/routes/__layout.svelte
+++ b/dotcom/src/routes/__layout.svelte
@@ -33,6 +33,6 @@
 <style>
 	main {
 		padding: var(--grid-double) 0;
-		margin: 0 auto;
+		margin: -1px auto 1px;
 	}
 </style>

--- a/dotcom/src/routes/__layout.svelte
+++ b/dotcom/src/routes/__layout.svelte
@@ -19,27 +19,6 @@
 	import "../app.css";
 	import "../ibm-plex-var.css";
 
-	const setTheme = (theme: "light" | "dark" | "default") => {
-		document.body.classList.add("themed");
-		const { classList } = document.querySelector("html");
-		classList.remove("light", "dark", "default");
-		switch (theme) {
-			case "light":
-				classList.add("light");
-				localStorage.setItem("theme", "light");
-				break;
-			case "dark":
-				classList.add("dark");
-				localStorage.setItem("theme", "dark");
-				break;
-			case "default":
-				classList.add("default");
-				localStorage.removeItem("theme");
-				break;
-		}
-		return theme;
-	};
-
 	export let lang: Lang;
 </script>
 
@@ -48,10 +27,6 @@
 <main>
 	<slot />
 </main>
-
-<button on:click={() => setTheme("light")}>light</button>
-<button on:click={() => setTheme("dark")}>dark</button>
-<button on:click={() => setTheme("default")}>reset</button>
 
 <Footer {lang} />
 

--- a/dotcom/src/routes/__layout.svelte
+++ b/dotcom/src/routes/__layout.svelte
@@ -57,7 +57,7 @@
 
 <style>
 	main {
-		padding: 1rem;
+		padding: var(--grid-double) 0;
 		margin: 0 auto;
 	}
 </style>

--- a/dotcom/static/grid.svg
+++ b/dotcom/static/grid.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="36" height="36">
+	<g fill="hsl(200, 96%, 3%)">
+		<circle cx="9" cy="9" r="1" />
+		<circle cx="9" cy="27" r="1" />
+		<circle cx="27" cy="9" r="1" />
+		<circle cx="27" cy="27" r="1" />
+	</g>
+</svg>


### PR DESCRIPTION
Add a dot grid using the darkest colour `var(--skies)`.

The sizing is currently set at 18px or 1.125rem. The dots are offset by a half grid.
The body has a half-grid padding to make everything work.

When elements are introduced, they need to make sure they fit right in the grid.

