### PR TITLE
fix: Group all svelte packages together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,10 @@
 			"matchCurrentVersion": "!/^0/",
 			"automerge": true,
 			"automergeType": "branch"
+		},
+		{
+			"groupName": "Svelte",
+			"matchPackagePrefixes": ["@sveltejs/"]
 		}
 	]
 }


### PR DESCRIPTION
Currently, svelte packages are bumped separately:

- #66 
- #51 
- #63  

