### PR TITLE
fix(theme): smoother colour transitions

### DIFF
--- a/dotcom/src/app.css
+++ b/dotcom/src/app.css
@@ -53,11 +53,10 @@ body {
 
 	font-size: 16px;
 	background-color: var(--clouds);
-	color: var(--earth);
 }
 
 body.themed {
-	transition: all 1.2s;
+	transition: background-color 1.2s;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -110,22 +109,25 @@ picture {
 	--ratio: 9;
 	width: calc(var(--width) * var(--grid));
 	height: calc(var(--width) * var(--ratio) * var(--grid));
+	color: var(--skies);
 	background-image: linear-gradient(
 			to bottom right,
 			transparent calc(50% - 1px),
-			var(--skies) calc(50% - 1px),
-			var(--skies) calc(50% + 1px),
+			currentColor calc(50% - 1px),
+			currentColor calc(50% + 1px),
 			transparent calc(50% + 1px)
 		),
 		linear-gradient(
 			to top right,
 			transparent calc(50% - 1px),
-			var(--skies) calc(50% - 1px),
-			var(--skies) calc(50% + 1px),
+			currentColor calc(50% - 1px),
+			currentColor calc(50% + 1px),
 			transparent calc(50% + 1px)
 		);
 	background-position: calc(0.5 * var(--grid-x)) var(--grid-y);
 	background-size: var(--grid-x) var(--grid-y);
+
+	transition: color 1.2s;
 }
 
 picture::after {
@@ -135,7 +137,7 @@ picture::after {
 	left: -1px;
 	right: -1px;
 	bottom: -1px;
-	border: 2px solid var(--skies);
+	border: 2px solid currentColor;
 }
 
 picture img {
@@ -162,12 +164,27 @@ picture + picture {
 	padding-block: calc(0.25 * var(--grid-y));
 	padding-inline: calc(0.25 * var(--grid-x));
 	line-height: var(--grid);
+	color: var(--earth);
 
-	background-image: radial-gradient(circle at 25% 75%, var(--skies) 1px, transparent 1px),
-		radial-gradient(circle at 75% 25%, var(--skies) 1px, transparent 1px);
+	position: relative;
+}
+
+#grid::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: -1;
+	color: var(--skies);
+
+	background-image: radial-gradient(circle at 25% 75%, currentColor 1px, transparent 1px),
+		radial-gradient(circle at 75% 25%, currentColor 1px, transparent 1px);
 	background-position: top left;
 	background-size: var(--grid-x) var(--grid-y);
-	background-clip: padding-box;
+}
+
+.themed #grid,
+.themed #grid::before {
+	transition: color 1.2s;
 }
 
 @media screen and (min-width: 360px) {

--- a/dotcom/src/lib/Footer.svelte
+++ b/dotcom/src/lib/Footer.svelte
@@ -59,7 +59,9 @@
 		position: absolute;
 		top: -1px;
 		width: 100%;
-		border-top: 2px solid var(--skies);
+		border-top: 2px solid currentColor;
+		color: var(--skies);
+		transition: color 1.2s;
 	}
 
 	p {

--- a/dotcom/src/lib/Header.svelte
+++ b/dotcom/src/lib/Header.svelte
@@ -66,7 +66,9 @@
 		position: absolute;
 		width: 100%;
 		bottom: -1px;
-		border-bottom: 2px solid var(--skies);
+		border-bottom: 2px solid currentColor;
+		color: var(--skies);
+		transition: color 1.2s;
 	}
 
 	ul {
@@ -129,7 +131,8 @@
 		content: "";
 		position: absolute;
 		inset: -1px;
-		border: 2px solid var(--frame);
+		border: 2px solid;
+		border-color: var(--frame, transparent);
 		pointer-events: none;
 		transform: translateY(-1px);
 	}

--- a/dotcom/src/lib/Works.svelte
+++ b/dotcom/src/lib/Works.svelte
@@ -71,7 +71,8 @@
 		height: 100%;
 		padding: 0.5rem;
 		border-radius: 1px;
-		border: 2px solid var(--skies);
+		border: 2px solid;
+		border-color: var(--skies);
 	}
 
 	li h3 {


### PR DESCRIPTION
Use css properties that are explicitely colours to ensure smooth transitions.

The idea popped in my head as I was talking to @raphaelkabo