### PR TITLE
Limit concurrent Renovate PRs to 3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
 	"extends": ["config:base"],
 	"labels": ["dependencies"],
 	"schedule": ["after 10am and before 6pm every weekday"],
+	"prConcurrentLimit": 3,
 	"packageRules": [
 		{
 			"matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
There’s only so much one can review at any given time, and this should improve the speed at which renovate runs, and limit the amout of deployements on Vercel.

https://docs.renovatebot.com/configuration-options/#prconcurrentlimit
