### PR TITLE
Prerender directive location

### DIFF
--- a/dotcom/src/lib/Footer.svelte
+++ b/dotcom/src/lib/Footer.svelte
@@ -18,7 +18,7 @@
 	{:else}
 		<p>
 			En ligne depuis 2007.<br />
-			Faites-moi signe par <a href="mailto:allo@mxdvl.com">courriel</a>, ou
+			Faites-moi signe via <a href="mailto:allo@mxdvl.com">courriel</a>, ou
 			<a href="https://t.me/mxdvl">telegram</a>.<br />
 			Pronoms: il/lui.
 		</p>
@@ -44,7 +44,12 @@
 					q: ["repo:mxdvl/mxdvl", "path:/\\.(svelte|md)/", `path:${path.split("/").at(-1)}`].join(" "),
 				}).toString()}`,
 				"https://github.com/",
-			).href}>Edit content</a
+			).href}
+			>{#if $lang == "fr"}
+				Suggérer une modification
+			{:else}
+				Propose an edit
+			{/if}</a
 		>.
 	</p>
 

--- a/dotcom/src/routes/+layout.ts
+++ b/dotcom/src/routes/+layout.ts
@@ -1,8 +1,9 @@
-import { pathLang } from "$lib/lang";
+import { lang as langStore, pathLang } from "$lib/lang";
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = async ({ url }) => {
 	const lang = pathLang(url.pathname);
+	langStore.set(lang);
 	return {
 		lang,
 	};

--- a/dotcom/src/routes/allô/+page.server.ts
+++ b/dotcom/src/routes/allô/+page.server.ts
@@ -1,1 +1,3 @@
 export { load } from "../hi/+page.server";
+
+export const prerender = true;

--- a/dotcom/src/routes/erreur/+page.svelte
+++ b/dotcom/src/routes/erreur/+page.svelte
@@ -1,2 +1,6 @@
+<script lang="ts">
+	export const prerender = true;
+</script>
+
 <h3>Perdu</h3>
 <p>Rien à voir ici, malheureusement :(</p>

--- a/dotcom/src/routes/error/+page.svelte
+++ b/dotcom/src/routes/error/+page.svelte
@@ -1,2 +1,6 @@
+<script lang="ts">
+	export const prerender = true;
+</script>
+
 <h3>Not Found</h3>
 <p>Nothing to see here, sadly :(</p>

--- a/dotcom/src/routes/hi/+page.server.ts
+++ b/dotcom/src/routes/hi/+page.server.ts
@@ -1,6 +1,8 @@
 import { getWeather } from "$lib/weather";
 import type { PageServerLoad } from "./$types";
 
+export const prerender = true;
+
 export const load: PageServerLoad = async () => {
 	const data = await getWeather("london");
 

--- a/dotcom/svelte.config.js
+++ b/dotcom/svelte.config.js
@@ -11,9 +11,6 @@ const config = {
 
 	kit: {
 		adapter: vercel(),
-		prerender: {
-			entries: ["/hi", "/allô", "/error", "/erreur"],
-		},
 	},
 };
 


### PR DESCRIPTION
## What does this change?

Remove the prerender global config in favour of individual pages.
Implement changes from https://github.com/sveltejs/kit/pull/6392.

Also fix the language of the header and footer prerender setting the `lang` server-side.