### PR TITLE
Pin Deno to 1.39

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v1.39
 
       - name: Format
         run: deno fmt deno


### PR DESCRIPTION
Otherwise the linter errors on the presence of `window`