### PR TITLE
Make Svelte LSP work with runes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -30,5 +30,8 @@
 	},
 	"lint": {
 		"include": ["deno", "deno.json"]
+	},
+	"imports": {
+		"svelte": "npm:svelte@5.7.1"
 	}
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,9 @@
 {
 	"tasks": {
-		"dev": "deno run --watch -A deno/mononykus.ts --watch",
+		"dev": {
+			"command": "deno run --watch -A deno/mononykus.ts --watch",
+			"dependencies": ["svelte:lsp"]
+		},
 		"build": "deno task build:mononykus && deno task build:icons && deno task build:media",
 		"build:icons": "deno run --allow-read --allow-write=build --allow-net --allow-ffi --allow-sys deno/scripts/process_icons.ts",
 		"build:media": "deno run --allow-read=deno/media,build/media --allow-write=build/media deno/media.ts",
@@ -9,6 +12,7 @@
 			"dependencies": ["clean"]
 		},
 		"clean": "rm -rf build",
+		"svelte:lsp": "deno install --node-modules-dir --no-lock",
 		"serve": {
 			"command": "deno run --allow-read --allow-net deno/server.ts",
 			"dependencies": ["build"]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"tasks": {
 		"dev": {
-			"command": "deno run --watch -A deno/mononykus.ts --watch",
+			"command": "NODE_ENV=development deno run --watch -A deno/mononykus.ts --watch",
 			"dependencies": ["svelte:lsp"]
 		},
 		"build": "deno task build:mononykus && deno task build:icons && deno task build:media",

--- a/deno.lock
+++ b/deno.lock
@@ -354,5 +354,10 @@
     "zimmerframe@1.1.2": {
       "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:svelte@5.7.1"
+    ]
   }
 }


### PR DESCRIPTION
### Before

```js
const single = $state(42);
//    ^? any
const triple = $derived(single * 3);
//    ^? any
```

### After

```js
const single = $state(42);
//    ^? number
const triple = $derived(single * 3);
//    ^? number
```

## Why `svelte@5.7.1`?

It’s [what `mononykus` uses](https://jsr.io/@mxdvl/mononykus@0.8.1/dependencies)